### PR TITLE
Remove ID when create a new distribution

### DIFF
--- a/src/DistributionBundle/Utils/DistributionService.php
+++ b/src/DistributionBundle/Utils/DistributionService.php
@@ -173,8 +173,7 @@ class DistributionService
         $this->em->flush();
 
         $name = $distribution->getName();
-        $id = $distribution->getId();
-        $distribution->setName($id.'-'.$name);
+        $distribution->setName($name);
 
         $this->em->persist($distribution);
 


### PR DESCRIPTION
Remove the field "id" when we create a new disitribution 